### PR TITLE
Standardize the display of two-round conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ To add or update a deadline:
 - Make sure it has the `title`, `year`, `id`, `link`, `deadline`, `timezone`, `date`, `place`, `sub` attributes
     + See available timezone strings [here](https://momentjs.com/timezone/).
 - Optionally add a `note` and `abstract_deadline` in case the conference has a separate mandatory abstract deadline
+- `deadline` can be a single timestamp or a list of timestamps. For multiple submission rounds, list the deadlines in round order; they will be displayed as Round 1, Round 2, and so on.
 - Send a pull request
 
 ## Origin

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -3,10 +3,11 @@
   year: 2027
   id: oopsla27
   link: https://conf.researchr.org/track/splash-2027/splashoopsla2027
-  deadline: '2027-04-07 23:59:59'
+  deadline:
+    - '2026-10-14 23:59:59'
+    - '2027-04-07 23:59:59'
   date: Sun 10 - Fri 15 October 2027
   place: Prague, Czechia
-  note: Round 1 deadline on 14 October 2026 (AoE)
 - title: ESOP
   year: 2027
   id: esop27

--- a/_layouts/calendar.ics
+++ b/_layouts/calendar.ics
@@ -14,14 +14,23 @@ DTSTART;TZID=Etc/GMT{{ tz }}:{{ conf.abstract_deadline | date: "%Y%m%dT%H%M%S" }
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
 DTSTART;TZID={{ conf.timezone }}:{{ conf.abstract_deadline | date: "%Y%m%dT%H%M%S" }}
 {% endif %}END:VEVENT{% endif %}
-{% if conf.deadline != "TBA" %}BEGIN:VEVENT
-SUMMARY:{{ conf.title }} {{ conf.year }} deadline
-UID:{{ conf.id }} {% if conf.timezone contains "UTC" %} {% assign tz = conf.timezone | split: "UTC" %} {% if tz[1] contains "-" %} {% assign tz = tz[1] | replace: "-", "+" %} {% else if tz[1] contains "+" %} {% assign tz = tz[1] | replace: "+", "-" %} {% else assign tz = tz[1] %} {% endif %}
+{% if conf.deadline.first %}
+{% assign deadlines = conf.deadline %}
+{% assign multiple_deadlines = true %}
+{% else %}
+{% assign deadlines = conf.deadline | split: "|||" %}
+{% assign multiple_deadlines = false %}
+{% endif %}
+{% for deadline in deadlines %}
+{% if deadline != "TBA" %}BEGIN:VEVENT
+SUMMARY:{{ conf.title }} {{ conf.year }}{% if multiple_deadlines %} Round {{ forloop.index }}{% endif %} deadline
+UID:{{ conf.id }}{% if multiple_deadlines %}r{{ forloop.index }}{% endif %} {% if conf.timezone contains "UTC" %} {% assign tz = conf.timezone | split: "UTC" %} {% if tz[1] contains "-" %} {% assign tz = tz[1] | replace: "-", "+" %} {% else if tz[1] contains "+" %} {% assign tz = tz[1] | replace: "+", "-" %} {% else assign tz = tz[1] %} {% endif %}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
-DTSTART;TZID=Etc/GMT{{ tz }}:{{ conf.deadline | date: "%Y%m%dT%H%M%S" }}
+DTSTART;TZID=Etc/GMT{{ tz }}:{{ deadline | date: "%Y%m%dT%H%M%S" }}
 {% else %}
 DTSTAMP:{{ site.time | date: "%Y%m%dT%H%M%SZ" }}
-DTSTART;TZID={{ conf.timezone }}:{{ conf.deadline | date: "%Y%m%dT%H%M%S" }}
+DTSTART;TZID={{ conf.timezone }}:{{ deadline | date: "%Y%m%dT%H%M%S" }}
 {% endif %}END:VEVENT
 {% endif %}
+{% endfor %}
 {%- endfor -%}END:VCALENDAR

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -43,10 +43,19 @@
             </div>
         </div>
         {% for conf in site.data.conferences %}
-        <div id="{{conf.id}}">
+        {% if conf.deadline.first %}
+          {% assign deadlines = conf.deadline %}
+          {% assign multiple_deadlines = true %}
+        {% else %}
+          {% assign deadlines = conf.deadline | split: "|||" %}
+          {% assign multiple_deadlines = false %}
+        {% endif %}
+        {% for deadline in deadlines %}
+        {% capture deadline_id %}{{conf.id}}{% if multiple_deadlines %}r{{forloop.index}}{% endif %}{% endcapture %}
+        <div id="{{deadline_id}}">
           <div class="row conf-row">
               <div class="col-xs-5 col-sm-6">
-                  <a class="conf-title" href="{{conf.link}}">{{conf.title}} {{conf.year}}</a>
+                  <a class="conf-title" href="{{conf.link}}">{{conf.title}} {{conf.year}}{% if multiple_deadlines %} · Round {{forloop.index}}{% endif %}</a>
               </div>
               <div class="col-xs-7 col-sm-6">
                 <span class="timer"></span>
@@ -81,6 +90,7 @@
           </div>
           <hr>
         </div>
+        {% endfor %}
         {% endfor %}
         <footer>
           <div class="row">
@@ -117,23 +127,32 @@
         }
 
         {% for conf in site.data.conferences %}
-        {% if conf.deadline == "TBA" %}
-          $('#{{conf.id}} .timer').html("TBA");
-          $('#{{conf.id}} .deadline-time').html("TBA");
+        {% if conf.deadline.first %}
+          {% assign deadlines = conf.deadline %}
+          {% assign multiple_deadlines = true %}
+        {% else %}
+          {% assign deadlines = conf.deadline | split: "|||" %}
+          {% assign multiple_deadlines = false %}
+        {% endif %}
+        {% for deadline in deadlines %}
+        {% capture deadline_id %}{{conf.id}}{% if multiple_deadlines %}r{{forloop.index}}{% endif %}{% endcapture %}
+        {% if deadline == "TBA" %}
+          $('#{{deadline_id}} .timer').html("TBA");
+          $('#{{deadline_id}} .deadline-time').html("TBA");
         {% else %}
           // adjust date according to deadline timezone
           var timezone = {% if conf.timezone %}"{{conf.timezone}}" {% else %} "Etc/GMT+12" {% endif %};
-          var confDate = moment.tz("{{conf.deadline}}", timezone);
+          var confDate = moment.tz("{{deadline}}", timezone);
 
           // render countdown timer
-          $('#{{conf.id}} .timer').countdown(confDate.toDate(), function(event) {
+          $('#{{deadline_id}} .timer').countdown(confDate.toDate(), function(event) {
             $(this).html(event.strftime('%D days %Hh %Mm %Ss'));
           });
 
           // convert deadline to local timezone
           try {
             var localConfDate = moment.tz(confDate, local_timezone);
-            $('#{{conf.id}} .deadline-time').html(localConfDate.toString());
+            $('#{{deadline_id}} .deadline-time').html(localConfDate.toString());
           }
           catch(err) {
             console.log("Error converting to local timezone.");
@@ -145,11 +164,11 @@
               class: 'calendar-obj',
 
               // You can pass an ID. If you don't, one will be generated for you
-              id: '{{conf.id}}'
+              id: '{{deadline_id}}'
             },
             data: {
               // Event title
-              title: '{{conf.title}} {{conf.year}} deadline',
+              title: '{{conf.title}} {{conf.year}}{% if multiple_deadlines %} Round {{forloop.index}}{% endif %} deadline',
 
               // Event start date
               start: confDate.toDate(), // new Date('June 15, 2013 19:00'),
@@ -158,13 +177,14 @@
               duration: 60,
             }
           });
-          document.querySelector('#{{conf.id}} .calendar').appendChild(myCalendar);
+          document.querySelector('#{{deadline_id}} .calendar').appendChild(myCalendar);
 
           // check if date has passed, add 'past' class to it
           var today = moment();
           if (today.diff(confDate) > 0)
-            $('#{{conf.id}}').addClass('past');
+            $('#{{deadline_id}}').addClass('past');
         {% endif %}
+        {% endfor %}
         {% endfor %}
     });
     <!-- Google analytics -->


### PR DESCRIPTION
Many PL conferences have adopted two-round submission cycles. Currently, one round is shown as the main deadline while the other appears only in a note. This makes the second deadline easy to miss, even though both rounds are equally important.

This PR standardizes the presentation of two-round conferences by displaying each round as a separate list item. Round labels are also included in calendar exports, while existing single-round entries remain unchanged.

The rendered result is:

<img width="1017" height="590" alt="image" src="https://github.com/user-attachments/assets/dfceb43e-80f7-4046-b02e-32f87d6bbe7a" />

Feel free to change any code or style.